### PR TITLE
Method changes, and bug fix when inserting data into YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,15 @@ db = PyBase("example", "JSON")  #=> ./example.json
 pybase_info = {"pybase": "awesomeness", "version": "0.1.0"}
 # Lets insert the defined dict inside our database.
 db.insert(pybase_info)  #=> {'pybase': 'awesomeness', 'version': '0.1.0'}
-print(db.read())
+print(db.get())
 # Lets delete an object inside our database cuz it's useless.
 db.delete('pybase')  #=> {'version': '0.1.0'}
-print(db.read())
+print(db.get())
 # Lets fetch an object inside our database and display its type.
 # It's useful to debug and manipulate the data dynamically.
 print(db.fetch('version'))
+#Gets the corresponding value according to the specified key
+print(db.get("version")) #=> '0.1.0'
 ```
 
 ## Documentation

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -11,10 +11,12 @@ db = PyBase("example", "JSON")  #=> ./example.json
 pybase_info = {"pybase": "awesomeness", "version": "0.1.0"}
 # Lets insert the defined dict inside our database.
 db.insert(pybase_info)  #=> {'pybase': 'awesomeness', 'version': '0.1.0'}
-print(db.read())
+print(db.get())
 # Lets delete an object inside our database cuz it's useless.
 db.delete('pybase')  #=> {'version': '0.1.0'}
-print(db.read())
+print(db.get())
 # Lets fetch an object inside our database and display its type.
 # It's useful to debug and manipulate the data dynamically.
 print(db.fetch('version'))
+#Gets the corresponding value according to the specified key
+print(db.get("version")) #=> '0.1.0'

--- a/pybase/pybase_db.py
+++ b/pybase/pybase_db.py
@@ -1,4 +1,4 @@
-#       NTBBloodbath | PyBase v0.0.1       #
+#       NTBBloodbath | PyBase v0.1.3       #
 ############################################
 # PyBase is distributed under MIT License. #
 
@@ -6,9 +6,9 @@
 import yaml
 import json
 import sqlite3
+import pickle
 import pathlib
 import os
-from os import path
 
 
 class PyBase:
@@ -30,7 +30,7 @@ class PyBase:
         Fetch an object and its sub_objects inside the database established in PyBase init.
     insert(content: dict)
         Insert a dictionary content inside the given database file.
-    read()
+    get(key: str=None)
         Read the database file established in PyBase init to to access its objects.
             
     TODO:
@@ -53,7 +53,7 @@ class PyBase:
             The name of the database without extension.
         db_type : str
             The database type.
-            Available types: yaml, json, sqlite
+            Available types: yaml, json, sqlite, bytes
         db_path : str
             The path where the database is located (default is current working directory).
             Example: /home/bloodbath/Desktop/PyBase
@@ -74,7 +74,7 @@ class PyBase:
             raise TypeError('database must be a String.')
         elif type(db_type) != str:
             raise TypeError('db_type must be a String.')
-        elif path.exists(db_path) != True:
+        elif os.path.exists(db_path) != True:
             raise FileNotFoundError(
                 f'The path ({self.__path}) wasn\'t found. Please check that the path exists.'
             )
@@ -83,7 +83,7 @@ class PyBase:
             ) if db_type != 'SQLite' else '.db'
             self.__DB = (f'{self.__path}/{database}{self.__EXTENSION}')
             if db_type.lower() == 'json':
-                if path.exists(self.__DB) == False:
+                if os.path.exists(self.__DB) == False:
                     try:
                         with open(self.__DB, mode='w+',
                                   encoding='utf-8') as json_file:
@@ -91,15 +91,23 @@ class PyBase:
                     except Exception as err:
                         print(f'[ERROR]: {err}')
             elif db_type.lower() == 'yaml':
-                if path.exists(self.__DB) == False:
+                if os.path.exists(self.__DB) == False:
                     try:
                         with open(self.__DB, mode='w+',
                                   encoding='utf-8') as yaml_file:
-                            yaml.dump("---", yaml_file)
+                            yaml.dump({}, yaml_file)
                     except Exception as err:
                         print(f'[ERROR]: {err}')
+            elif db_type.lower() == "bytes":
+                if not os.path.exists(self.__DB):
+                    try:
+                        with open(self.__DB, mode="wb") as bytes_file:
+                            pickle.dump({}, bytes_file)
+                    except Exception as err:
+                        print(f"[ERROR] - {err}")
             elif db_type.lower() == 'sqlite':
-                self.__sql_conn = sqlite3.connect(self.__DB)
+                #self.__sql_conn = sqlite3.connect(self.__DB)
+                print("[INFO] - SQLite not support, coming soon...")
             else:
                 raise ValueError('db_type must be JSON, YAML or SQLite.')
 
@@ -147,6 +155,15 @@ class PyBase:
                         yaml.dump(data, yaml_file, sort_keys=True)
                 except KeyError as err:
                     print(f'[ERROR]: {err}')
+            elif self.__EXTENSION == '.bytes':
+                try:
+                    with open(self.__DB, mode="rb") as bytes_file:
+                        data = pickle.load(bytes_file)
+                        data.pop(obj)
+                    with open(self.__DB, mode="wb") as bytes_file:
+                        pickle.dump(data, bytes_file)
+                except KeyError as err:
+                    print(f"[ERROR] - {err}")
 
     def exists(self, database: str, db_path: str = pathlib.Path().absolute()):
         """
@@ -179,7 +196,7 @@ class PyBase:
         elif type(db_path) != str:
             raise TypeError('db_path must be a String.')
         else:
-            if path.exists(f'{db_path}/{database}') == True:
+            if os.path.exists(f'{db_path}/{database}'):
                 return True
             else:
                 return False
@@ -288,7 +305,36 @@ class PyBase:
                                 return type(data[key])
                             except KeyError as e:
                                 print(f'[ERROR]: {err}')
-
+            elif self.__EXTENSION == '.bytes':
+                with open(self.__DB, mode='rb') as bytes_file:
+                    data = pickle.load(bytes_file)
+                    for key in list(obj):
+                        if key in data and sub != None and len(sub) != 0:
+                            try:
+                                # Establish the maximum deep of the fetch to 5 objects.
+                                if len(sub) == 1 and list(
+                                        sub)[0] in data[key].keys():
+                                    return type(data[key][list(sub)[0]])
+                                elif len(sub) == 2 and list(
+                                        sub)[1] in data[key].keys():
+                                    return type(data[key][list(sub)[1]])
+                                elif len(sub) == 3 and list(
+                                        sub)[2] in data[key].keys():
+                                    return type(data[key][list(sub)[2]])
+                                elif len(sub) == 4 and list(
+                                        sub)[3] in data[key].keys():
+                                    return type(data[key][list(sub)[3]])
+                                elif len(sub) == 5 and list(
+                                        sub)[4] in data[key].keys():
+                                    return type(data[key][list(sub)[4]])
+                            except KeyError as err:
+                                print(f'[ERROR]: {err}')
+                        else:
+                            try:
+                                return type(data[key])
+                            except KeyError as err:
+                                print(f'[ERROR]: {err}')
+            
     def insert(self, content: dict):
         """
         Insert a dictionary content inside the database file established in PyBase init.
@@ -330,35 +376,99 @@ class PyBase:
                 except Exception as err:
                     print(f'[ERROR]: {err}')
 
-    def read(self):
+            elif self.__EXTENSION == '.bytes':
+                try:
+                    with open(self.__DB, mode="rb") as bytes_file:
+                        data = pickle.load(bytes_file) or {}
+                        data.update(content)
+                    with open(self.__DB, mode='wb') as bytes_file:
+                        pickle.dump(data, bytes_file)
+                except Exception as err:
+                    print(f'[ERROR]: {err}')
+
+    def get(self, key: str = None):
+
         """
-        Read the database file established in PyBase init to access its objects.
+        Read the database file established in PyBase init to access its objects or values ​​using the key.
 
         ...
 
         Parameters
         ----------
+        key : str
+            The key of the first value of the dictionary
+            Default: None
 
         Raises
         ------
+        KeyError
+            When the key does not exist in the specified file type
 
         Returns
         -------
-        dict
+        dict 
             A dictionary which contains all the database objects.
         """
+        try:
+            if self.__EXTENSION == ".json":
+                if key is None:
+                    with open(self.__DB, mode="r+", encoding="utf-8") as json_file:
+                        data = json.load(json_file) or {}
+                        self.__close_file_delete(json_file)
+                        return data
+                else:
+                    with open(self.__DB, mode="r+", encoding="utf-8") as json_file:
+                        data = json.load(json_file) or {}
+                        self.__close_file_delete(json_file)
+                        if key in data: return data[key]
+                        else:
+                            raise KeyError(f"\"{key}\" Does not exist in the file")
+            elif self.__EXTENSION == ".yaml":
+                if key is None:
+                    with open(self.__DB, mode='r+', encoding='utf-8') as yaml_file:
+                        data = yaml.load(yaml_file, Loader=yaml.FullLoader) or {}
+                        self.__close_file_delete(yaml_file)
+                        return data
+                else:
+                    with open(self.__DB, mode='r+', encoding='utf-8') as yaml_file:
+                        data = yaml.load(yaml_file, Loader=yaml.FullLoader) or {}
+                        self.__close_file_delete(yaml_file)
+                        if key in data: return data[key]
+                        else:
+                            raise KeyError(f"\"{key}\" Does not exist in the file")
+            elif self.__EXTENSION == ".bytes":
+                if key is None:
+                    with open(self.__DB, mode="rb") as bytes_file:
+                        data = pickle.load(bytes_file)
+                        self.__close_file_delete(bytes_file)
+                        return data
+                else:        
+                    with open(self.__DB, mode='rb') as bytes_file:
+                        data = pickle.load(bytes_file) or {}
+                        self.__close_file_delete(bytes_file)
+                        if key in data: return data[key]
+                        else:
+                            raise KeyError(f"\"{key}\" Does not exist in the file")
+        except Exception as err:
+            print(f'[ERROR]: {err}')
+    
+    
+    def __close_file_delete(self, file):
+        """   
+        Method only for the class, close the open file and erase it from memory (slightly better performance)
+        ...
 
-        if self.__EXTENSION == '.json':
-            try:
-                with open(self.__DB, mode='r+', encoding='utf-8') as json_file:
-                    data = json.load(json_file)
-                    return data
-            except Exception as err:
-                print(f'[ERROR]: {err}')
-        elif self.__EXTENSION == '.yaml':
-            try:
-                with open(self.__DB, mode='r+', encoding='utf-8') as yaml_file:
-                    data = yaml.load(yaml_file, Loader=yaml.FullLoader)
-                    return data
-            except Exception as err:
-                print(f'[ERROR]: {err}')
+        Parameters
+        ----------
+        file
+            an open (or closed) file
+
+        Raises
+        ------
+        """
+        try:
+            close_file = file.close()
+            if close_file is None:
+                del (file)
+        except Exception as err:
+            print(f"[ERROR] - {err}")


### PR DESCRIPTION
1. And add support for serialization in .bytes files
2. Change the `read()` method to `get()` and this method has a parameter that is optional, if you don't put that parameter it returns all the data in the file, if you put the parameter it will look for the "key" in the file and returns its value if it exists, if it does not exist it will return an error.

Example:
```py
#Import pybase
from pybase import PyBase
# new db
db = PyBase("MyDB", "Bytes")
#Inserting data into a serialized file
db.insert({"key": "value", "anotherKey":"AnotherValue"}) #Ok

#Getting all the data from the file
print(db.get()) #=> {"key":"value","anotherKey":"AnotherValue"}

#Obtaining a value according to your key
print(db.get("anotherKey")) #=> "AnotherValue"
print(db.get("key")) #=> "value"

#Error
print(db.get("OtherKey")) #=> Error
```
3. Not so important: Updating the example and the example of the `README.md` and the version (only in the pybase_db file)

